### PR TITLE
Add gstreamer pipeline for nvidia hardware decoding

### DIFF
--- a/gs-test.py
+++ b/gs-test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import sys
+
+import gi
+
+gi.require_version('GLib', '2.0')
+gi.require_version('GObject', '2.0')
+gi.require_version('Gst', '1.0')
+
+from gi.repository import Gst, GObject, GLib
+
+pipeline = None
+bus = None
+message = None
+
+# initialize GStreamer
+Gst.init(sys.argv[1:])
+
+# build the pipeline
+pipeline = Gst.parse_launch(
+    "playbin uri=https://gstreamer.freedesktop.org/data/media/sintel_trailer-480p.webm"
+)
+
+# start playing
+pipeline.set_state(Gst.State.PLAYING)
+
+# wait until EOS or error
+bus = pipeline.get_bus()
+msg = bus.timed_pop_filtered(
+    Gst.CLOCK_TIME_NONE,
+    Gst.MessageType.ERROR | Gst.MessageType.EOS
+)
+
+# free resources
+pipeline.set_state(Gst.State.NULL)

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
 import sys
 import vpi
 import numpy as np
@@ -31,21 +32,22 @@ from argparse import ArgumentParser
 import cv2
 import time
 
+# GStreamer imports
+import gi
+gi.require_version('Gst', '1.0')
+from gi.repository import Gst
+
 # Motion detection parameters
 MOTION_PIXEL_THRESHOLD = 500  # Minimum number of motion pixels to trigger detection (tune as needed)
 CONTOUR_AREA_THRESHOLD = 100  # Minimum area for a contour to be considered motion (optional, for bounding boxes)
 
+
 # ----------------------------
 # Parse command line arguments
-
 parser = ArgumentParser()
-parser.add_argument('backend', choices=['cpu','cuda'],
-                    help='Backend to be used for processing')
-
-parser.add_argument('input',
-                    help='Input video to be denoised')
-
-args = parser.parse_args();
+parser.add_argument('backend', choices=['cpu','cuda'], help='Backend to be used for processing')
+parser.add_argument('input', help='Input video to be denoised (file path or URI)')
+args = parser.parse_args()
 
 if args.backend == 'cuda':
     backend = vpi.Backend.CUDA
@@ -53,14 +55,127 @@ else:
     assert args.backend == 'cpu'
     backend = vpi.Backend.CPU
 
+
 # -----------------------------
-# Open input video and check
-inVideo = cv2.VideoCapture(args.input)
-if not inVideo.isOpened():
-    print(f"Error: Could not open input video file '{args.input}'")
+# GStreamer initialization with timing
+import datetime
+gst_init_start = time.time()
+print(f"[{datetime.datetime.now().isoformat()}] Starting GStreamer initialization...")
+Gst.init(None)
+gst_init_end = time.time()
+print(f"[{datetime.datetime.now().isoformat()}] GStreamer initialized. Took {gst_init_end-gst_init_start:.3f} seconds.")
+
+def build_nvidia_gst_pipeline(uri):
+    """
+    Build a GStreamer pipeline string using NVIDIA hardware decoder if possible.
+    Only supports local files (mp4, mkv, mov, avi) with H.264/H.265 for now.
+    Falls back to software decoding if nvv4l2decoder is not available.
+    """
+    import os
+    from urllib.parse import urlparse
+    # Prefer nvh264dec (x86_64 RTX) over nvv4l2decoder (Jetson/embedded)
+    nvh264_available = Gst.ElementFactory.find("nvh264dec") is not None
+    nvv4l2_available = Gst.ElementFactory.find("nvv4l2decoder") is not None
+    # Determine if local file or URI
+    parsed = urlparse(uri)
+    if parsed.scheme in ("file", ""):
+        # Local file
+        path = parsed.path if parsed.scheme else uri
+        ext = os.path.splitext(path)[1].lower()
+        if ext in [".mp4", ".mov", ".mkv", ".avi"]:
+            # Use qtdemux for mp4/mov, matroskademux for mkv, avidemux for avi
+            if ext in [".mp4", ".mov"]:
+                demux = "qtdemux"
+            elif ext == ".mkv":
+                demux = "matroskademux"
+            elif ext == ".avi":
+                demux = "avidemux"
+            else:
+                demux = "qtdemux"
+            if nvh264_available:
+                print("[INFO] Using NVIDIA nvh264dec for hardware-accelerated decoding (x86_64, RTX).")
+                pipeline = (
+                    f"filesrc location=\"{path}\" ! {demux} ! h264parse ! nvh264dec ! "
+                    "videoconvert ! video/x-raw,format=BGR ! appsink name=sink"
+                )
+            elif nvv4l2_available:
+                print("[INFO] Using NVIDIA nvv4l2decoder for hardware-accelerated decoding (Jetson/embedded).")
+                pipeline = (
+                    f"filesrc location=\"{path}\" ! {demux} ! h264parse ! nvv4l2decoder ! "
+                    "videoconvert ! video/x-raw,format=BGR ! appsink name=sink"
+                )
+            else:
+                print("[WARNING] No NVIDIA hardware decoder found. Falling back to software decoding (avdec_h264). To enable hardware acceleration, install NVIDIA GStreamer plugins.")
+                pipeline = (
+                    f"filesrc location=\"{path}\" ! {demux} ! h264parse ! avdec_h264 ! "
+                    "videoconvert ! video/x-raw,format=BGR ! appsink name=sink"
+                )
+            return pipeline
+        else:
+            # Fallback to uridecodebin for other formats
+            return f"uridecodebin uri={uri} ! videoconvert ! video/x-raw,format=BGR ! appsink name=sink"
+    else:
+        # For network streams, fallback to uridecodebin
+        return f"uridecodebin uri={uri} ! videoconvert ! video/x-raw,format=BGR ! appsink name=sink"
+
+def gstreamer_frame_generator(uri):
+    """
+    GStreamer pipeline to read frames and yield them as numpy arrays (BGR), using NVIDIA decoder if possible.
+    """
+    import datetime
+    pipeline_str = build_nvidia_gst_pipeline(uri)
+    pipeline_start = time.time()
+    print(f"[{datetime.datetime.now().isoformat()}] Starting GStreamer pipeline creation and set_state...")
+    pipeline = Gst.parse_launch(pipeline_str)
+    appsink = pipeline.get_by_name('sink')
+    appsink.set_property('emit-signals', True)
+    appsink.set_property('sync', False)
+    pipeline.set_state(Gst.State.PLAYING)
+    pipeline_end = time.time()
+    print(f"[{datetime.datetime.now().isoformat()}] GStreamer pipeline ready. Took {pipeline_end-pipeline_start:.3f} seconds.")
+    try:
+        while True:
+            sample = appsink.emit('try-pull-sample', Gst.SECOND)
+            if sample is None:
+                break
+            buf = sample.get_buffer()
+            caps = sample.get_caps()
+            arr = None
+            # Extract width, height
+            structure = caps.get_structure(0)
+            width = structure.get_value('width')
+            height = structure.get_value('height')
+            # Get data
+            success, mapinfo = buf.map(Gst.MapFlags.READ)
+            if not success:
+                break
+            try:
+                data = mapinfo.data
+                arr = np.frombuffer(data, dtype=np.uint8).reshape((height, width, 3))
+            finally:
+                buf.unmap(mapinfo)
+            yield arr
+    finally:
+        pipeline.set_state(Gst.State.NULL)
+
+# Helper to get video size from first frame
+def get_video_size(uri):
+    for frame in gstreamer_frame_generator(uri):
+        return (frame.shape[1], frame.shape[0])
+    return (0, 0)
+
+# Accept both file paths and URIs
+def to_gst_uri(path):
+    if path.startswith('http://') or path.startswith('https://') or path.startswith('file://'):
+        return path
+    import pathlib
+    return pathlib.Path(path).absolute().as_uri()
+
+input_uri = to_gst_uri(args.input)
+inSize = get_video_size(input_uri)
+if inSize == (0, 0):
+    print(f"Error: Could not open input video file '{args.input}' via GStreamer")
     sys.exit(1)
-inSize = (int(inVideo.get(cv2.CAP_PROP_FRAME_WIDTH)), int(inVideo.get(cv2.CAP_PROP_FRAME_HEIGHT)))
-fps = inVideo.get(cv2.CAP_PROP_FPS)
 
 #--------------------------------------------------------------
 # Create the Background Subtractor object using the backend specified by the user
@@ -68,19 +183,11 @@ with backend:
     bgsub = vpi.BackgroundSubtractor(inSize, vpi.Format.BGR8)
 
 #--------------------------------------------------------------
-# Main processing loop
+# Main processing loop using GStreamer
 start_time = time.time()
 idxFrame = 0
-while True:
-    # print("Processing frame {}".format(idxFrame))
-    idxFrame+=1
-
-    # Read one input frame
-    ret, cvFrame = inVideo.read()
-    if not ret:
-        idxFrame -= 1  # Don't count the last increment if no frame was read
-        break
-
+for cvFrame in gstreamer_frame_generator(input_uri):
+    idxFrame += 1
     # Get the foreground mask and background image estimates
     fgmask, bgimage = bgsub(vpi.asimage(cvFrame, vpi.Format.BGR8), learnrate=0.01)
 


### PR DESCRIPTION
- Add GStreamer pipeline to use the Nvidia hardware decoder to read the video frames 
- Log the time stamps 